### PR TITLE
openlayers - popup by click visible during "highlight on hover"

### DIFF
--- a/openlayers/qgis2web.js
+++ b/openlayers/qgis2web.js
@@ -239,7 +239,7 @@ var onSingleClick = function(evt) {
     var clusteredFeatures;
     var popupText = '<ul>';
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
-        if (feature instanceof ol.Feature && (layer.get("interactive") || layer.get("interactive") == undefined)) {
+        if (layer && feature instanceof ol.Feature && (layer.get("interactive") || layer.get("interactive") == undefined)) {
             var doPopup = false;
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {


### PR DESCRIPTION
Popup doesn't work unless clicked and the pointer is moved quickly. This way we are checking if the layer exists first.