### PR TITLE
openlayers: max-height of popup-content

### DIFF
--- a/openlayers/qgis2web.css
+++ b/openlayers/qgis2web.css
@@ -71,8 +71,8 @@ html, body {
 	font-size: 12px;
     line-height: 1.2;
     margin-top: 5px;
-	max-height: 50vw;
-	max-width: 50vw;
+	max-height: 90vh;
+	max-width: 70vw;
 	overflow: auto;
 }
 


### PR DESCRIPTION
changed max-height of popup-content to 90vh

viewport-width (vw) is used in multiple places where vh would be more appropriate. More fixes are needed.

max-width changed to 70vw, this allows for easy closing of the popup in my test